### PR TITLE
Override global config by program config if available. #66 #C4GT

### DIFF
--- a/impl/c-qube/ingest/configMerge.js
+++ b/impl/c-qube/ingest/configMerge.js
@@ -1,0 +1,35 @@
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mergeConfigs = void 0;
+var fs = require("fs");
+function mergeConfigs(globalConfig, programConfigs) {
+    var mergedConfig = __assign(__assign({}, globalConfig), { programs: [] });
+    for (var _i = 0, programConfigs_1 = programConfigs; _i < programConfigs_1.length; _i++) {
+        var programConfig = programConfigs_1[_i];
+        var mergedProgramConfig = __assign(__assign({}, programConfig), { dimensions: __assign(__assign({}, globalConfig.dimensions), programConfig.dimensions), './output': {
+                location: programConfig['./output'].location,
+            } });
+        mergedConfig.programs.push(mergedProgramConfig);
+    }
+    return mergedConfig;
+}
+exports.mergeConfigs = mergeConfigs;
+// Step 1: Read the global configuration
+var globalConfig = JSON.parse(fs.readFileSync('config.json', 'utf-8'));
+// Step 2: Read the program-specific configurations
+var programConfigs = globalConfig.programs;
+// Step 3: Merge the program-specific configurations into the global configuration, with program-specific values overriding the global values
+var mergedConfig = mergeConfigs(globalConfig, programConfigs);
+// Step 4: Use the merged configuration throughout the program
+console.log(mergedConfig);

--- a/impl/c-qube/ingest/configMerge.ts
+++ b/impl/c-qube/ingest/configMerge.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+
+export interface GlobalConfig {
+  globals: {
+    onlyCreateWhitelisted: boolean;
+  };
+  dimensions: {
+    namespace: string;
+    fileNameFormat: string;
+    input: {
+      files: string;
+    };
+  };
+  programs: ProgramConfig[];
+}
+
+export interface ProgramConfig {
+  name: string;
+  namespace: string;
+  description: string;
+  shouldIngestToDB: boolean;
+  input: {
+    files: string;
+  };
+  './output': {
+    location: string;
+  };
+  dimensions: {
+    whitelisted: string[];
+    blacklisted: string[];
+  };
+}
+
+export function mergeConfigs(globalConfig: GlobalConfig, programConfigs: ProgramConfig[]): GlobalConfig {
+  const mergedConfig: GlobalConfig = {
+    ...globalConfig,
+    programs: [],
+  };
+
+  for (const programConfig of programConfigs) {
+    const mergedProgramConfig: ProgramConfig = {
+      ...programConfig,
+      dimensions: {
+        ...globalConfig.dimensions,
+        ...programConfig.dimensions,
+      },
+      './output': {
+        location: programConfig['./output'].location,
+      },
+    };
+
+    mergedConfig.programs.push(mergedProgramConfig);
+  }
+
+  return mergedConfig;
+}
+
+const globalConfig: GlobalConfig = JSON.parse(fs.readFileSync('config.json', 'utf-8'));
+
+const programConfigs: ProgramConfig[] = globalConfig.programs;
+
+const mergedConfig: GlobalConfig = mergeConfigs(globalConfig, programConfigs);
+
+console.log(mergedConfig);

--- a/impl/c-qube/ingest/test.js
+++ b/impl/c-qube/ingest/test.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var fs = require("fs");
+var configMerge_1 = require("./configMerge"); // Assuming the configuration merge functions and types are exported from 'configMerge.ts'
+// Step 1: Read the content of the 'config.json' file
+var configJson = fs.readFileSync('config.json', 'utf-8');
+// Step 2: Parse the JSON content into an object
+var configData = JSON.parse(configJson);
+// Step 3: Extract the global config and program configs from the parsed data
+var globalConfig = configData;
+var programConfigs = configData.programs;
+// Step 4: Merge the configurations
+var mergedConfig = (0, configMerge_1.mergeConfigs)(globalConfig, programConfigs);
+// Test case to check if the program-specific configurations are overridden
+console.log('Global Config:', globalConfig);
+console.log('Program Configs:', programConfigs);
+console.log('Merged Config:', mergedConfig);

--- a/impl/c-qube/ingest/test.ts
+++ b/impl/c-qube/ingest/test.ts
@@ -1,0 +1,15 @@
+import * as fs from 'fs';
+import { mergeConfigs, GlobalConfig, ProgramConfig } from './configMerge'; 
+
+const configJson = fs.readFileSync('config.json', 'utf-8');
+
+const configData = JSON.parse(configJson);
+
+const globalConfig: GlobalConfig = configData;
+const programConfigs: ProgramConfig[] = configData.programs;
+
+const mergedConfig: GlobalConfig = mergeConfigs(globalConfig, programConfigs);
+
+console.log('Global Config:', globalConfig);
+console.log('Program Configs:', programConfigs);
+console.log('Merged Config:', mergedConfig);


### PR DESCRIPTION
This is code to override global config by program config. This is ouput of configMerge which I used to override global configs by merging configs. Also created a test case which checks global configs, program configs and give mixed configs which shows program config overriding global configs. 
![image](https://github.com/ChakshuGautam/cQube-ingestion/assets/100033918/307db6a3-efae-419b-b140-4f3893164771)
