### PR TITLE
fix tests for event grammar

### DIFF
--- a/impl/c-qube/src/services/csv-adapter/parser/dimension-grammar/dimension-grammar.service.spec.ts
+++ b/impl/c-qube/src/services/csv-adapter/parser/dimension-grammar/dimension-grammar.service.spec.ts
@@ -1,26 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DimensionGrammarService } from './dimension-grammar.service';
-import { promises as fsMock } from 'fs';
 import {
   getDimensionColumns,
   getDimensionNameFromFilePath,
   getPrimaryKeyAndIndexes,
 } from './dimension-grammar.helpers';
 import { Column, ColumnType } from '../../types/parser';
-
-const mockReadFile = async (
-  path: string,
-  encoding: string,
-): Promise<string> => {
-  if (path === 'invalid-dimension.grammar.csv') return ``;
-  if (path === 'incorrect-length.grammar.csv')
-    return `PK,,,,,,,,,,
-  string,string,string,string,string,string,string,string,string,string
-  school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude`;
-  return `PK,,,,,,,,,,
-  string,string,string,string,string,string,string,string,string,string,string
-  school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude`;
-};
 
 describe('DimensionGrammarService', () => {
   let service: DimensionGrammarService;
@@ -34,13 +19,11 @@ describe('DimensionGrammarService', () => {
   });
 
   it('should create a DimensionGrammar from CSV definition', async () => {
-    // Override the default 'fs.readFile' method with the mock
-    (fsMock.readFile as any) = mockReadFile;
+    const csvFilePath =
+      './test/fixtures/test-csvs/event-grammars/school-dimension.grammar.csv';
 
     const dimensionGrammar =
-      await service.createDimensionGrammarFromCSVDefinition(
-        'school-dimension.grammar.csv',
-      );
+      await service.createDimensionGrammarFromCSVDefinition(csvFilePath);
 
     expect(dimensionGrammar.name).toEqual('school');
     expect(dimensionGrammar.storage.primaryId).toEqual('school_id');
@@ -55,115 +38,108 @@ describe('DimensionGrammarService', () => {
       true,
     );
   });
-  describe('createDimensionGrammarFromCSVDefinition', () => {
-    it('should create a DimensionGrammar from CSV definition', async () => {
-      const dimensionGrammar =
-        await service.createDimensionGrammarFromCSVDefinition(
-          'school-dimension.grammar.csv',
-        );
 
-      expect(dimensionGrammar.name).toBe('school');
-      expect(dimensionGrammar.storage.primaryId).toBe('school_id');
-      expect(dimensionGrammar.storage.indexes).toEqual(['name']);
-      expect(dimensionGrammar.schema.properties['school_name'].type).toBe(
-        'string',
-      );
-      expect(dimensionGrammar.schema.properties['school_name'].unique).toBe(
-        false,
-      );
-      expect(dimensionGrammar.schema.properties['school_id'].unique).toBe(true);
-    });
+  it('should return null when CSV format is invalid', async () => {
+    const csvFilePath =
+      './test/fixtures/test-csvs/event-grammars/invalid-dimension.grammar.csv';
 
-    it('should return null when CSV format is invalid', async () => {
-      const dimensionGrammar =
-        await service.createDimensionGrammarFromCSVDefinition(
-          'invalid-dimension.grammar.csv',
-        );
+    const dimensionGrammar =
+      await service.createDimensionGrammarFromCSVDefinition(csvFilePath);
 
-      expect(dimensionGrammar).toBeNull();
-    });
-
-    it('should return null when CSV format is invalid - incorrect length of columns', async () => {
-      const dimensionGrammar =
-        await service.createDimensionGrammarFromCSVDefinition(
-          'incorrect-length.grammar.csv',
-        );
-
-      expect(dimensionGrammar).toBeNull();
-    });
+    expect(dimensionGrammar).toBeNull();
   });
 
-  describe('getDimensionNameFromFilePath', () => {
-    it('should get the dimension name from a file path', () => {
-      const dimensionName = getDimensionNameFromFilePath(
-        'path/to/school-dimension.grammar.csv',
-      );
+  it('should return null when CSV format is invalid - incorrect length of columns', async () => {
+    const csvFilePath =
+      './test/fixtures/test-csvs/event-grammars/incorrect_length-dimension.grammar.csv';
 
-      expect(dimensionName).toBe('school');
+    const dimensionGrammar =
+      await service.createDimensionGrammarFromCSVDefinition(csvFilePath);
+
+    expect(dimensionGrammar).toBeNull();
+  });
+});
+
+describe('getDimensionNameFromFilePath', () => {
+  it('should get the dimension name from a file path', () => {
+    const dimensionName = getDimensionNameFromFilePath(
+      'path/to/school-dimension.grammar.csv',
+    );
+
+    expect(dimensionName).toBe('school');
+  });
+});
+
+describe('getPrimaryKeyAndIndexes', () => {
+  it('should get the primary key and indexes from row1 and row3', () => {
+    const row1 = 'PK,,,,,,,';
+    const row3 =
+      'school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude';
+
+    const { pk, indexes } = getPrimaryKeyAndIndexes(row1, row3);
+
+    expect(pk).toBe('school_id');
+    expect(indexes).toEqual([]);
+  });
+});
+
+describe('getDimensionColumns', () => {
+  it('should get the dimension columns from row2 and row3', () => {
+    const row2 =
+      'string,string,string,string,string,string,string,string,string,string,string';
+    const row3 =
+      'school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude';
+
+    const dimensionColumns = getDimensionColumns(row2, row3);
+
+    expect(dimensionColumns.length).toBe(11);
+    expect(dimensionColumns[0]).toEqual({
+      name: 'school_id',
+      type: ColumnType.string,
+    });
+    expect(dimensionColumns[1]).toEqual({
+      name: 'school_name',
+      type: ColumnType.string,
     });
   });
+});
 
-  describe('getPrimaryKeyAndIndexes', () => {
-    it('should get the primary key and indexes from row1 and row3', () => {
-      const row1 = 'PK,,,,,,,';
-      const row3 =
-        'school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude';
+describe('createCompositeDimensionGrammar', () => {
+  let service: DimensionGrammarService;
 
-      const { pk, indexes } = getPrimaryKeyAndIndexes(row1, row3);
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DimensionGrammarService],
+    }).compile();
 
-      expect(pk).toBe('school_id');
-      expect(indexes).toEqual([]);
-    });
+    service = module.get<DimensionGrammarService>(DimensionGrammarService);
   });
 
-  describe('getDimensionColumns', () => {
-    it('should get the dimension columns from row2 and row3', () => {
-      const row2 =
-        'string,string,string,string,string,string,string,string,string,string,string';
-      const row3 =
-        'school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude';
+  it('should create a composite dimension grammar', () => {
+    const dimensionColumns: Column[] = [
+      { name: 'school_id', type: ColumnType.string },
+      { name: 'school_name', type: ColumnType.string },
+    ];
+    const name = 'school';
+    const primaryId = 'school_id';
+    const indexes: string[] = [];
 
-      const dimensionColumns = getDimensionColumns(row2, row3);
+    const dimensionGrammar = service.createCompositeDimensionGrammar(
+      dimensionColumns,
+      name,
+      primaryId,
+      indexes,
+    );
 
-      expect(dimensionColumns.length).toBe(11);
-      expect(dimensionColumns[0]).toEqual({
-        name: 'school_id',
-        type: ColumnType.string,
-      });
-      expect(dimensionColumns[1]).toEqual({
-        name: 'school_name',
-        type: ColumnType.string,
-      });
-    });
-  });
-
-  describe('createCompositeDimensionGrammar', () => {
-    it('should create a composite dimension grammar', () => {
-      const dimensionColumns: Column[] = [
-        { name: 'school_id', type: ColumnType.string },
-        { name: 'school_name', type: ColumnType.string },
-      ];
-      const name = 'school';
-      const primaryId = 'school_id';
-      const indexes: string[] = [];
-
-      const dimensionGrammar = service.createCompositeDimensionGrammar(
-        dimensionColumns,
-        name,
-        primaryId,
-        indexes,
-      );
-
-      expect(dimensionGrammar.name).toBe('school');
-      expect(dimensionGrammar.storage.primaryId).toBe('school_id');
-      expect(dimensionGrammar.storage.indexes).toEqual(['name']);
-      expect(dimensionGrammar.schema.properties['school_name'].type).toBe(
-        'string',
-      );
-      expect(dimensionGrammar.schema.properties['school_name'].unique).toBe(
-        false,
-      );
-      expect(dimensionGrammar.schema.properties['school_id'].unique).toBe(true);
-    });
+    expect(dimensionGrammar.name).toBe('school');
+    expect(dimensionGrammar.storage.primaryId).toBe('school_id');
+    expect(dimensionGrammar.storage.indexes).toEqual(['name']);
+    expect(dimensionGrammar.schema.properties['school_name'].type).toBe(
+      'string',
+    );
+    expect(dimensionGrammar.schema.properties['school_name'].unique).toBe(
+      false,
+    );
+    expect(dimensionGrammar.schema.properties['school_id'].unique).toBe(true);
   });
 });

--- a/impl/c-qube/src/services/csv-adapter/parser/event-grammar/event-grammar.service.spec.ts
+++ b/impl/c-qube/src/services/csv-adapter/parser/event-grammar/event-grammar.service.spec.ts
@@ -10,38 +10,38 @@ import { createCompositeDimensionGrammar } from '../dimension-grammar/dimension-
 const fs = require('fs');
 
 describe('EventGrammarService', () => {
-  // it('tests createDimensionGrammarFromCSVDefinition', async () => {
-  //   const csvFilePath =
-  //     './test/fixtures/test-csvs/event-grammars/test-dimension.grammar.csv';
+  it('tests createDimensionGrammarFromCSVDefinition', async () => {
+    const csvFilePath =
+      './test/fixtures/test-csvs/event-grammars/test-dimension.grammar.csv';
 
-  //   const fileContent = fs.readFileSync(csvFilePath, 'utf8');
-  //   console.log('fileContent: ', fileContent.split('\n'));
+    const fileContent = fs.readFileSync(csvFilePath, 'utf8');
+    console.log('fileContent: ', fileContent.split('\n'));
 
-  //   const data = await createDimensionGrammarFromCSVDefinition(csvFilePath);
-  //   console.log('data: ', data);
-  //   expect(data).toEqual({
-  //     description: '',
-  //     name: 'test',
-  //     type: 'dynamic',
-  //     storage: {
-  //       indexes: ['name'],
-  //       primaryId: 'state_id',
-  //       retention: null,
-  //       bucket_size: null,
-  //     },
-  //     schema: {
-  //       title: 'test',
-  //       psql_schema: 'dimensions',
-  //       properties: {
-  //         state_id: { type: 'string', unique: true },
-  //         state_name: { type: 'string', unique: true },
-  //         latitude: { type: 'string', unique: false },
-  //         longitude: { type: 'string', unique: false },
-  //       },
-  //       indexes: [{ columns: [['state_name']] }],
-  //     },
-  //   });
-  // });
+    const data = await createDimensionGrammarFromCSVDefinition(csvFilePath);
+    console.log('data: ', data);
+    expect(data).toEqual({
+      description: '',
+      name: 'test',
+      type: 'dynamic',
+      storage: {
+        indexes: ['name'],
+        primaryId: 'state_id',
+        retention: null,
+        bucket_size: null,
+      },
+      schema: {
+        title: 'test',
+        psql_schema: 'dimensions',
+        properties: {
+          state_id: { type: 'string', unique: true },
+          state_name: { type: 'string', unique: true },
+          latitude: { type: 'string', unique: false },
+          longitude: { type: 'string', unique: false },
+        },
+        indexes: [{ columns: [['state_name']] }],
+      },
+    });
+  });
 
   it('tests createCompositeDimensionGrammars', () => {
     const dimensionColumns: Column[] = [

--- a/impl/c-qube/src/services/csv-adapter/parser/utils/csvcleaner.spec.ts
+++ b/impl/c-qube/src/services/csv-adapter/parser/utils/csvcleaner.spec.ts
@@ -24,12 +24,18 @@ describe('remove empty lines', () => {
   });
   test('test get files in directory', async () => {
     const files = await getFilesInDirectory('./test/fixtures/test-csvs');
-    expect(files).toEqual([
+    const expectedFiles = [
       'test/fixtures/test-csvs/csvcleaner/withEmpty.csv',
       'test/fixtures/test-csvs/csvcleaner/withoutEmpty.csv',
       'test/fixtures/test-csvs/csvreader/invalid.reader.csv',
       'test/fixtures/test-csvs/csvreader/valid.reader.csv',
       'test/fixtures/test-csvs/event-grammars/test-dimension.grammar.csv',
-    ]);
+      'test/fixtures/test-csvs/event-grammars/incorrect_length-dimension.grammar.csv',
+      'test/fixtures/test-csvs/event-grammars/invalid-dimension.grammar.csv',
+      'test/fixtures/test-csvs/event-grammars/school-dimension.grammar.csv',
+    ];
+    files.sort();
+    expectedFiles.sort();
+    expect(files).toEqual(expectedFiles);
   });
 });

--- a/impl/c-qube/test/fixtures/test-csvs/event-grammars/incorrect_length-dimension.grammar.csv
+++ b/impl/c-qube/test/fixtures/test-csvs/event-grammars/incorrect_length-dimension.grammar.csv
@@ -1,0 +1,3 @@
+PK,,,,,,,,,,
+string,string,string,string,string,string,string,string,string,string
+school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude

--- a/impl/c-qube/test/fixtures/test-csvs/event-grammars/school-dimension.grammar.csv
+++ b/impl/c-qube/test/fixtures/test-csvs/event-grammars/school-dimension.grammar.csv
@@ -1,0 +1,3 @@
+PK,,,,,,,,,,
+string,string,string,string,string,string,string,string,string,string,string
+school_id,school_name,schoolcategory_id,cluster_id,cluster_name,block_id,block_name,district_id,district_name,latitude,longitude

--- a/impl/c-qube/yarn.lock
+++ b/impl/c-qube/yarn.lock
@@ -402,6 +402,11 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"
@@ -708,6 +713,16 @@
     tslib "2.4.1"
     uuid "9.0.0"
 
+"@nestjs/config@^2.3.1":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@nestjs/config/-/config-2.3.4.tgz#6378a3c5b163a429e9ba728f28eed7513855bd50"
+  integrity sha512-IGdSF+0F9MJO6dCRTEahdxPz4iVijjtolcFBxnY+2QYM3bXYQvAgzskGZi+WkAFJN/VzR3TEp60gN5sI74GxPA==
+  dependencies:
+    dotenv "16.1.4"
+    dotenv-expand "10.0.0"
+    lodash "4.17.21"
+    uuid "9.0.0"
+
 "@nestjs/core@^9.0.0":
   version "9.2.1"
   resolved "https://registry.npmjs.org/@nestjs/core/-/core-9.2.1.tgz"
@@ -796,6 +811,40 @@
   version "4.8.1"
   resolved "https://registry.npmjs.org/@prisma/engines/-/engines-4.8.1.tgz"
   integrity sha512-93tctjNXcIS+i/e552IO6tqw17sX8liivv8WX9lDMCpEEe3ci+nT9F+1oHtAafqruXLepKF80i/D20Mm+ESlOw==
+
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.5.8":
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.5.8.tgz#a375ba7861825bd0d2dc512282b8bff7b98dbcb1"
+  integrity sha512-xzElwHIO6rBAqzPeVnCzgvrnBEcFL1P0w8P65VNLRkdVW8rOE58f52hdj0BDgmsdOm4f1EoXPZtH4Fh7M/qUpw==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.0.tgz#cc2b82e5141a29ada2cce7d267a6b74baa6dd519"
+  integrity sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==
+
+"@redis/json@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.4.tgz#f372b5f93324e6ffb7f16aadcbcb4e5c3d39bda1"
+  integrity sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==
+
+"@redis/search@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.1.3.tgz#b5a6837522ce9028267fe6f50762a8bcfd2e998b"
+  integrity sha512-4Dg1JjvCevdiCBTZqjhKkGoC5/BcB7k9j99kdMnaXFXg8x4eyOIVg9487CMv7/BUVkFLZCaIh8ead9mU15DNng==
+
+"@redis/time-series@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.4.tgz#af85eb080f6934580e4d3b58046026b6c2b18717"
+  integrity sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -1581,6 +1630,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
+
 buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
@@ -1608,6 +1662,13 @@ bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+cache-manager-redis-store@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cache-manager-redis-store/-/cache-manager-redis-store-3.0.1.tgz#8eeb211212763d04cef4058666182d624f714299"
+  integrity sha512-o560kw+dFqusC9lQJhcm6L2F2fMKobJ5af+FoR2PdnMVdpQ3f3Bz6qzvObTGyvoazQJxjQNWgMQeChP4vRTuXQ==
+  dependencies:
+    redis "^4.3.1"
 
 cache-manager@^5.2.1:
   version "5.2.1"
@@ -1749,6 +1810,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+cluster-key-slot@1.1.2, cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -1975,6 +2041,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
+denque@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
@@ -2021,6 +2092,16 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dotenv-expand@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
+  integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
+dotenv@16.1.4:
+  version "16.1.4"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.1.4.tgz#67ac1a10cd9c25f5ba604e4e08bc77c0ebe0ca8c"
+  integrity sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2547,6 +2628,11 @@ function-bind@^1.1.1:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
@@ -2796,6 +2882,21 @@ interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+ioredis@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.3.2.tgz#9139f596f62fc9c72d873353ac5395bcf05709f7"
+  integrity sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -3416,6 +3517,16 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
@@ -3451,9 +3562,9 @@ lodash.xor@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz"
   integrity sha512-sVN2zimthq7aZ5sPGXnSz32rZPuqcparVW50chJQe+mzTYV+IsxSsl/2gnkWWE2Of7K3myBQBqtLKOUEHJKRsQ==
 
-lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.3:
+lodash@4.17.21, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.3:
   version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.1.0:
@@ -3855,6 +3966,11 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -3911,6 +4027,64 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pg-cloudflare@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
+  integrity sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==
+
+pg-connection-string@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.6.2.tgz#713d82053de4e2bd166fab70cd4f26ad36aab475"
+  integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.6.1.tgz#5a902eda79a8d7e3c928b77abf776b3cb7d351f7"
+  integrity sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==
+
+pg-protocol@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.0.tgz#4c91613c0315349363af2084608db843502f8833"
+  integrity sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==
+
+pg-types@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.10.0:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.11.3.tgz#d7db6e3fe268fcedd65b8e4599cda0b8b4bf76cb"
+  integrity sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.6.2"
+    pg-pool "^3.6.1"
+    pg-protocol "^1.6.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+  optionalDependencies:
+    pg-cloudflare "^1.1.1"
+
+pgpass@1.x:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -3978,6 +4152,28 @@ pluralize@8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -4150,6 +4346,30 @@ rechoir@^0.6.2:
   integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
   dependencies:
     resolve "^1.1.6"
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^4.3.1, redis@^4.6.6:
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.6.7.tgz#c73123ad0b572776223f172ec78185adb72a6b57"
+  integrity sha512-KrkuNJNpCwRm5vFJh0tteMxW8SaUzkm5fBH7eL5hd/D0fAkzvapxbfGPP/r+4JAXdQuX7nebsBkBqA2RHB7Usw==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.5.8"
+    "@redis/graph" "1.1.0"
+    "@redis/json" "1.0.4"
+    "@redis/search" "1.1.3"
+    "@redis/time-series" "1.0.4"
 
 reflect-metadata@^0.1.13:
   version "0.1.13"
@@ -4423,7 +4643,7 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
-split2@^4.0.0:
+split2@^4.0.0, split2@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
   integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
@@ -4439,6 +4659,11 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
 statuses@2.0.1:
   version "2.0.1"
@@ -4985,15 +5210,15 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@4.0.0, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:
   version "1.10.2"


### PR DESCRIPTION
Related to #102  #115 

The tests for `event grammar` were failing because when we were mocking the `fs.readFile` function, the mocked function persisted for subsequent tests that ran and were always getting the hard-coded value. 